### PR TITLE
Make 1d integer sorting parallel

### DIFF
--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -1,13 +1,23 @@
 #define TORCH_ASSERT_NO_OPERATORS
 #include <ATen/native/Sorting.h>
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstring>
+#include <limits>
+#include <utility>
+
 #include <ATen/core/TensorBase.h>
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/NumericUtils.h>
 #include <ATen/TensorIterator.h>
+#include <ATen/cpu/vec/functional.h>
+#include <ATen/cpu/vec/vec.h>
 #include <ATen/native/StridedRandomAccessor.h>
 #include <ATen/native/CompositeRandomAccessor.h>
 #include <ATen/native/TopKImpl.h>
+#include <ATen/native/cpu/radix_sort.h>
 #include <c10/core/WrapDimMinimal.h>
 #include <c10/util/irange.h>
 
@@ -83,6 +93,104 @@ struct KeyValueCompDesc {
   }
 };
 
+template <typename scalar_t>
+std::pair<scalar_t, scalar_t> get_min_max(const scalar_t* data, int64_t size) {
+  using Vec = vec::Vectorized<vec::vec_scalar_t<scalar_t>>;
+  int num_threads = at::get_num_threads();
+  std::vector<scalar_t> min_per_thread(num_threads, std::numeric_limits<scalar_t>::max());
+  std::vector<scalar_t> max_per_thread(num_threads, std::numeric_limits<scalar_t>::lowest());
+
+  at::parallel_for(0, size, at::internal::GRAIN_SIZE / num_threads, [&](int64_t begin, int64_t end) {
+    int tid = at::get_thread_num();
+    const scalar_t* local_data = data + begin;
+    const int64_t local_size = end - begin;
+    const auto local_min_max = at::vec::reduce2_all(
+            [](Vec x, Vec y) { return at::vec::minimum(x, y); },
+            [](Vec x, Vec y) { return at::vec::maximum(x, y); },
+            local_data,
+            local_size);
+    min_per_thread[tid] = local_min_max.first;
+    max_per_thread[tid] = local_min_max.second;
+  });
+
+  scalar_t global_min = min_per_thread[0];
+  scalar_t global_max = max_per_thread[0];
+  for (const auto i : c10::irange(1, num_threads)) {
+    if (min_per_thread[i] < global_min) {
+      global_min = min_per_thread[i];
+    }
+    if (max_per_thread[i] > global_max) {
+      global_max = max_per_thread[i];
+    }
+  }
+
+  return std::pair<scalar_t, scalar_t>(global_min, global_max);
+}
+
+static void parallel_sort1d_kernel(
+    const TensorBase& values,
+    const TensorBase& indices,
+    bool descending) {
+  // this kernel does not care about `stable` parameter as radix sort
+  // used here is a stable sorting algorithm
+  AT_DISPATCH_INTEGRAL_TYPES(values.scalar_type(), "parallel_sort1d_kernel", [&] {
+    scalar_t min = std::numeric_limits<scalar_t>::max();
+    scalar_t max = std::numeric_limits<scalar_t>::lowest();
+    std::tie(min, max) =
+        get_min_max(values.data_ptr<scalar_t>(), values.size(0));
+
+    int64_t elements = values.numel();
+    scalar_t* keys = values.data_ptr<scalar_t>();
+    int64_t* vals = indices.data_ptr<int64_t>();
+    std::vector<scalar_t> tmp_keys(elements);
+    std::vector<int64_t> tmp_vals(elements);
+    scalar_t* sorted_keys = nullptr;
+    int64_t* sorted_vals = nullptr;
+    std::tie(sorted_keys, sorted_vals) = radix_sort_parallel(
+        keys,
+        vals,
+        tmp_keys.data(),
+        tmp_vals.data(),
+        elements,
+        std::max(std::abs(min), std::abs(max)));
+
+    const bool sorted_in_place = keys == sorted_keys;
+    if (!sorted_in_place) {
+      std::memcpy(keys, sorted_keys, values.numel() * values.itemsize());
+      std::memcpy(vals, sorted_vals, indices.numel() * indices.itemsize());
+    }
+    if (min < 0) {
+      // values like [2, 4, 1, -3, 8, -9, -5, 5] will be sorted as follows
+      // (because of how negative values are stored): [1, 2, 4, 5, 8, -9, -5, -3]
+      int64_t neg_val_offset = 0;
+      for (const auto i : c10::irange(0, elements)) {
+        if (keys[i] < 0) {
+          neg_val_offset = i;
+          break;
+        }
+      }
+      // use tmp_keys and tmp_vals as a temporary buffer
+      std::memcpy(tmp_keys.data(), keys, neg_val_offset * values.itemsize());
+      std::memcpy(keys, keys + neg_val_offset, (elements - neg_val_offset) * values.itemsize());
+      std::memcpy(keys + elements - neg_val_offset, tmp_keys.data(), neg_val_offset * values.itemsize());
+      std::memcpy(tmp_vals.data(), vals, neg_val_offset * indices.itemsize());
+      std::memcpy(vals, vals + neg_val_offset, (elements - neg_val_offset) * indices.itemsize());
+      std::memcpy(vals + elements - neg_val_offset, tmp_vals.data(), neg_val_offset * indices.itemsize());
+    }
+    if (descending) {
+      int num_threads = at::get_num_threads();
+      at::parallel_for(0, elements / 2, at::internal::GRAIN_SIZE / num_threads, [&](int64_t begin, int64_t end) {
+        int64_t end_pos = elements - begin - 1;
+        for (const auto i : c10::irange(begin, end)) {
+          std::swap(keys[i], keys[end_pos]);
+          std::swap(vals[i], vals[end_pos]);
+          --end_pos;
+        }
+      });
+    }
+  });
+}
+
 static void sort_kernel(
     const TensorBase& self,
     const TensorBase& values,
@@ -92,6 +200,12 @@ static void sort_kernel(
     bool stable) {
   dim = maybe_wrap_dim(dim, values.dim());
   _fill_indices(indices, dim);
+  if (values.dim() == 1 && values.numel() >= at::internal::GRAIN_SIZE &&
+      at::isIntegralType(values.scalar_type(), /*includeBool=*/false) &&
+      is_radix_sort_available()) {
+    parallel_sort1d_kernel(values, indices, descending);
+    return;
+  }
   _dim_apply(
     values, indices, dim,
     "sort_cpu", [&](

--- a/aten/src/ATen/native/cpu/radix_sort.h
+++ b/aten/src/ATen/native/cpu/radix_sort.h
@@ -1,0 +1,205 @@
+#pragma once
+#include <ATen/Config.h>
+
+#if !AT_PARALLEL_OPENMP
+
+namespace at {
+namespace native {
+
+bool inline is_radix_sort_available() {
+  return false;
+}
+
+template <typename K, typename V>
+std::pair<K*, V*> radix_sort_parallel(
+    K* inp_key_buf,
+    V* inp_value_buf,
+    K* tmp_key_buf,
+    V* tmp_value_buf,
+    int64_t elements_count,
+    int64_t max_value) {
+  TORCH_CHECK(
+      false, "radix_sort_parallel: ATen is not compiled with OpenMP support");
+}
+
+} // namespace native
+} // namespace at
+
+#else
+
+#include <c10/util/llvmMathExtras.h>
+#include <omp.h>
+
+namespace at {
+namespace native {
+
+namespace {
+
+// `radix_sort_parallel` is primarily used for converting COO to CSR when
+// sorting the indices, which is used in scatter_reduce optimization on CPU.
+//
+// Copied from fbgemm implementation here:
+// https://github.com/pytorch/FBGEMM/blob/main/fbgemm_gpu/src/cpu_utils.cpp
+//
+// `radix_sort_parallel` is only available when ATen is compiled with OpenMP,
+// since the algorithm requires sync between omp threads, which can not be
+// perfectly mapped to `at::parallel_for` at the current stage.
+//
+
+// histogram size per thread
+constexpr int RDX_HIST_SIZE = 256;
+
+template <typename K, typename V>
+void radix_sort_kernel(
+    K* input_keys,
+    V* input_values,
+    K* output_keys,
+    V* output_values,
+    int elements_count,
+    int* histogram,
+    int* histogram_ps,
+    int pass) {
+  int tid = omp_get_thread_num();
+  int nthreads = omp_get_num_threads();
+  int elements_count_4 = elements_count / 4 * 4;
+
+  int* local_histogram = &histogram[RDX_HIST_SIZE * tid];
+  int* local_histogram_ps = &histogram_ps[RDX_HIST_SIZE * tid];
+
+  // Step 1: compute histogram
+  for (int i = 0; i < RDX_HIST_SIZE; i++) {
+    local_histogram[i] = 0;
+  }
+
+#pragma omp for schedule(static)
+  for (int64_t i = 0; i < elements_count_4; i += 4) {
+    K key_1 = input_keys[i];
+    K key_2 = input_keys[i + 1];
+    K key_3 = input_keys[i + 2];
+    K key_4 = input_keys[i + 3];
+
+    local_histogram[(key_1 >> (pass * 8)) & 0xFF]++;
+    local_histogram[(key_2 >> (pass * 8)) & 0xFF]++;
+    local_histogram[(key_3 >> (pass * 8)) & 0xFF]++;
+    local_histogram[(key_4 >> (pass * 8)) & 0xFF]++;
+  }
+  if (tid == (nthreads - 1)) {
+    for (int64_t i = elements_count_4; i < elements_count; ++i) {
+      K key = input_keys[i];
+      local_histogram[(key >> (pass * 8)) & 0xFF]++;
+    }
+  }
+#pragma omp barrier
+  // Step 2: prefix sum
+  if (tid == 0) {
+    int sum = 0, prev_sum = 0;
+    for (int bins = 0; bins < RDX_HIST_SIZE; bins++) {
+      for (int t = 0; t < nthreads; t++) {
+        sum += histogram[t * RDX_HIST_SIZE + bins];
+        histogram_ps[t * RDX_HIST_SIZE + bins] = prev_sum;
+        prev_sum = sum;
+      }
+    }
+    histogram_ps[RDX_HIST_SIZE * nthreads] = prev_sum;
+    TORCH_CHECK(prev_sum == elements_count);
+  }
+#pragma omp barrier
+
+  // Step 3: scatter
+#pragma omp for schedule(static)
+  for (int64_t i = 0; i < elements_count_4; i += 4) {
+    K key_1 = input_keys[i];
+    K key_2 = input_keys[i + 1];
+    K key_3 = input_keys[i + 2];
+    K key_4 = input_keys[i + 3];
+
+    int bin_1 = (key_1 >> (pass * 8)) & 0xFF;
+    int bin_2 = (key_2 >> (pass * 8)) & 0xFF;
+    int bin_3 = (key_3 >> (pass * 8)) & 0xFF;
+    int bin_4 = (key_4 >> (pass * 8)) & 0xFF;
+
+    int pos;
+    pos = local_histogram_ps[bin_1]++;
+    output_keys[pos] = key_1;
+    output_values[pos] = input_values[i];
+    pos = local_histogram_ps[bin_2]++;
+    output_keys[pos] = key_2;
+    output_values[pos] = input_values[i + 1];
+    pos = local_histogram_ps[bin_3]++;
+    output_keys[pos] = key_3;
+    output_values[pos] = input_values[i + 2];
+    pos = local_histogram_ps[bin_4]++;
+    output_keys[pos] = key_4;
+    output_values[pos] = input_values[i + 3];
+  }
+  if (tid == (nthreads - 1)) {
+    for (int64_t i = elements_count_4; i < elements_count; ++i) {
+      K key = input_keys[i];
+      int pos = local_histogram_ps[(key >> (pass * 8)) & 0xFF]++;
+      output_keys[pos] = key;
+      output_values[pos] = input_values[i];
+    }
+  }
+}
+
+} // namespace
+
+bool inline is_radix_sort_available() {
+  return true;
+}
+
+template <typename K, typename V>
+std::pair<K*, V*> radix_sort_parallel(
+    K* inp_key_buf,
+    V* inp_value_buf,
+    K* tmp_key_buf,
+    V* tmp_value_buf,
+    int64_t elements_count,
+    int64_t max_value) {
+  int maxthreads = omp_get_max_threads();
+  std::unique_ptr<int[]> histogram_tmp(new int[RDX_HIST_SIZE * maxthreads]);
+  std::unique_ptr<int[]> histogram_ps_tmp(
+      new int[RDX_HIST_SIZE * maxthreads + 1]);
+  int* histogram = histogram_tmp.get();
+  int* histogram_ps = histogram_ps_tmp.get();
+  if (max_value == 0) {
+    return std::make_pair(inp_key_buf, inp_value_buf);
+  }
+
+  // __builtin_clz is not portable
+  int num_bits = sizeof(K) * 8 -
+      llvm::countLeadingZeros(static_cast<std::make_unsigned_t<K>>(max_value));
+  unsigned int num_passes = (num_bits + 7) / 8;
+
+#pragma omp parallel
+  {
+    K* input_keys = inp_key_buf;
+    V* input_values = inp_value_buf;
+    K* output_keys = tmp_key_buf;
+    V* output_values = tmp_value_buf;
+
+    for (unsigned int pass = 0; pass < num_passes; pass++) {
+      radix_sort_kernel(
+          input_keys,
+          input_values,
+          output_keys,
+          output_values,
+          elements_count,
+          histogram,
+          histogram_ps,
+          pass);
+
+      std::swap(input_keys, output_keys);
+      std::swap(input_values, output_values);
+#pragma omp barrier
+    }
+  }
+  return (
+      num_passes % 2 == 0 ? std::make_pair(inp_key_buf, inp_value_buf)
+                          : std::make_pair(tmp_key_buf, tmp_value_buf));
+}
+
+} // namespace native
+} // namespace at
+
+#endif


### PR DESCRIPTION
In GNN workloads we use `torch.argsort` to calculate permutation from CSR to CSC sparse matrix storage format. Till now, sorting one-dimensional data was performed sequentially. This change reuses radix sort from fbgemm and makes `torch.(arg)sort` work in parallel.

Few comments on the implementation:

* `radix_sort` sorts only positive values in ascending order.
To fix that, post-processing is required. Values like `[2, 4, 1, -3, 8, -9, -5, 5]` will be sorted as follows (because of how negative values are stored): `[1, 2, 4, 5, 8, -9, -5, -3]`. We can find the first negative number position and perform a memory block swap to handle negative values. For sorting in descending order we need to reverse the values.
* why handle negative values and descending order?
Descending order can be added as a case for sequential (regular) execution. As for negative values, calculating min and max does have some cost, if we would like to fall back to the sequential version in case `min < 0`, that would make its execution slower than the current one.
* can we improve `radix_sort`?
Surely we can handle descending order. Negative values are a bit tricky (handling this case will definitely make `radix_sort` perform worse).

Taking into consideration all the above, we can also think about adding a new operation to [pyg-lib](https://github.com/pyg-team/pyg-lib). As we know that we will be sorting positive integer values, and we can estimate the maximum value, the new operation could look as follows (with reuse of `radix_sort` under the hood):
`def index_sort(indices, max=None)`

Performance measurements:
For the minimal tensor size (`at::internal::GRAIN_SIZE`) chosen for the parallel path, each configuration (`negative_values = [True, False], descending = [True, False=]`) brings the execution speedup. Below are measurements made for an inference step of [ogbn-products](https://github.com/snap-stanford/ogb/blob/master/examples/nodeproppred/products/gnn.py) benchmark (measured on a 10-core client machine):

* sequential version:
```
-------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
                                       Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
-------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
                     torch_sparse::spmm_sum        61.18%       43.355s        61.18%       43.355s       14.452s             3
                              aten::argsort         0.09%      61.391ms        31.80%       22.534s       11.267s             2
                                 aten::sort        31.25%       22.147s        31.71%       22.472s       11.236s             2
                                aten::index         1.59%        1.124s         1.82%        1.290s     128.976ms            10
                               aten::linear         0.00%      44.000us         1.39%     987.039ms     329.013ms             3
                               aten::matmul         0.00%      28.000us         1.39%     986.923ms     328.974ms             3
                                   aten::mm         1.39%     986.895ms         1.39%     986.895ms     328.965ms             3
                                  aten::add         0.94%     664.044ms         0.94%     664.044ms     166.011ms             4
                           aten::index_put_         0.00%      54.000us         0.83%     585.910ms     117.182ms             5
                     aten::_index_put_impl_         0.45%     315.541ms         0.83%     585.856ms     117.171ms             5
                              aten::nonzero         0.62%     435.836ms         0.62%     435.897ms      72.650ms             6
                                 aten::relu         0.00%      59.000us         0.50%     352.453ms     176.226ms             2
                            aten::clamp_min         0.50%     352.394ms         0.50%     352.394ms     176.197ms             2
                  torch_scatter::gather_csr         0.43%     307.036ms         0.43%     307.061ms     307.061ms             1
                torch_sparse::non_diag_mask         0.30%     214.760ms         0.32%     225.479ms     225.479ms             1
                                aten::copy_         0.32%     225.114ms         0.32%     225.114ms      37.519ms             6
                               aten::arange         0.15%     103.410ms         0.29%     206.905ms      34.484ms             6
                                  aten::max         0.19%     131.993ms         0.19%     132.041ms      26.408ms             5
                                  aten::mul         0.18%     127.097ms         0.18%     127.097ms      63.548ms             2
                          aten::log_softmax         0.00%      12.000us         0.09%      60.377ms      60.377ms             1
-------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 70.863s
```
* parallel version:
```
-------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
                                       Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
-------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
                     torch_sparse::spmm_sum        81.67%       42.634s        81.67%       42.634s       14.211s             3
                              aten::argsort         0.14%      74.714ms         8.75%        4.567s        2.284s             2
                                 aten::sort         7.98%        4.167s         8.61%        4.493s        2.246s             2
                                aten::index         2.28%        1.193s         2.64%        1.376s     137.633ms            10
                               aten::linear         0.00%      34.000us         2.22%        1.158s     385.886ms             3
                               aten::matmul         0.00%      28.000us         2.22%        1.158s     385.851ms             3
                                   aten::mm         2.22%        1.158s         2.22%        1.158s     385.842ms             3
                                  aten::add         1.00%     524.511ms         1.00%     524.511ms     131.128ms             4
                           aten::index_put_         0.00%      47.000us         0.99%     518.904ms     103.781ms             5
                     aten::_index_put_impl_         0.50%     263.414ms         0.99%     518.857ms     103.771ms             5
                              aten::nonzero         0.84%     438.706ms         0.84%     438.779ms      73.130ms             6
                  torch_scatter::gather_csr         0.59%     307.014ms         0.59%     307.049ms     307.049ms             1
                                 aten::relu         0.00%      36.000us         0.55%     288.729ms     144.364ms             2
                            aten::clamp_min         0.55%     288.693ms         0.55%     288.693ms     144.346ms             2
                torch_sparse::non_diag_mask         0.44%     230.263ms         0.46%     241.259ms     241.259ms             1
                                aten::copy_         0.43%     227.007ms         0.43%     227.007ms      37.834ms             6
                               aten::arange         0.19%      99.981ms         0.38%     200.044ms      33.341ms             6
                                  aten::mul         0.24%     127.047ms         0.24%     127.047ms      63.523ms             2
                                  aten::max         0.24%     125.825ms         0.24%     125.868ms      25.174ms             5
                          aten::log_softmax         0.00%      11.000us         0.14%      73.388ms      73.388ms             1
-------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 52.204s
```


