### PR TITLE
Make 1D integer sorting parallel

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -105,7 +105,7 @@
 [submodule "third_party/fbgemm"]
     ignore = dirty
     path = third_party/fbgemm
-    url = https://github.com/pytorch/fbgemm
+    url = https://github.com/DamianSzwichtenberg/fbgemm
 [submodule "third_party/foxi"]
     ignore = dirty
     path = third_party/foxi

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -15,7 +15,6 @@
 #include <ATen/native/TopKImpl.h>
 #include <c10/core/WrapDimMinimal.h>
 #include <c10/util/irange.h>
-#include <fbgemm/Config.h>
 #include <fbgemm/Utils.h>
 
 namespace at::native {
@@ -141,8 +140,8 @@ static void sort_kernel(
   }
   // TODO(dszwicht): Should we add here check for `stable` param?
   // Radix sort is a stable sorting algorithm.
-  if (FBGEMM_PARALLEL_OPENMP && values.dim() == 1 &&
-      values.numel() >= at::internal::GRAIN_SIZE &&
+  if (fbgemm::is_radix_sort_accelerated_with_openmp() &&
+      values.dim() == 1 && values.numel() >= at::internal::GRAIN_SIZE &&
       at::isIntegralType(values.scalar_type(), /*includeBool=*/false) &&
       !descending) {
     parallel_sort1d_kernel(values, indices);

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -100,9 +100,7 @@ static void parallel_sort1d_kernel(
     int64_t* vals = indices.data_ptr<int64_t>();
     std::vector<scalar_t> tmp_keys(elements);
     std::vector<int64_t> tmp_vals(elements);
-    scalar_t* sorted_keys = nullptr;
-    int64_t* sorted_vals = nullptr;
-    std::tie(sorted_keys, sorted_vals) = fbgemm::radix_sort_parallel(
+    const auto [sorted_keys, sorted_vals] = fbgemm::radix_sort_parallel(
         keys,
         vals,
         tmp_keys.data(),

--- a/aten/src/ATen/native/cpu/radix_sort.h
+++ b/aten/src/ATen/native/cpu/radix_sort.h
@@ -14,8 +14,7 @@ std::pair<K*, V*> radix_sort_parallel(
     K* tmp_key_buf,
     V* tmp_value_buf,
     int64_t elements_count,
-    int64_t max_value,
-    bool maybe_with_neg_vals = false) {
+    int64_t max_value) {
   TORCH_CHECK(false, "radix_sort_parallel: ATen is not compiled with OpenMP support");
 }
 
@@ -46,47 +45,6 @@ namespace {
 // histogram size per thread
 constexpr int RDX_HIST_SIZE = 256;
 
-void combine_prefix_sum(
-    int nthreads,
-    int elements_count,
-    int* histogram,
-    int* histogram_ps) {
-  int sum = 0, prev_sum = 0;
-  for (int bins = 0; bins < RDX_HIST_SIZE; bins++) {
-    for (int t = 0; t < nthreads; t++) {
-      sum += histogram[t * RDX_HIST_SIZE + bins];
-      histogram_ps[t * RDX_HIST_SIZE + bins] = prev_sum;
-      prev_sum = sum;
-    }
-  }
-  histogram_ps[RDX_HIST_SIZE * nthreads] = prev_sum;
-  TORCH_CHECK(prev_sum == elements_count);
-}
-
-void combine_prefix_sum_for_neg_vals(
-    int nthreads,
-    int elements_count,
-    int* histogram,
-    int* histogram_ps) {
-  int sum = 0, prev_sum = 0;
-  for (int bins = 128; bins < RDX_HIST_SIZE; bins++) {
-    for (int t = 0; t < nthreads; t++) {
-      sum += histogram[t * RDX_HIST_SIZE + bins];
-      histogram_ps[t * RDX_HIST_SIZE + bins] = prev_sum;
-      prev_sum = sum;
-    }
-  }
-  for (int bins = 0; bins < 128; bins++) {
-    for (int t = 0; t < nthreads; t++) {
-      sum += histogram[t * RDX_HIST_SIZE + bins];
-      histogram_ps[t * RDX_HIST_SIZE + bins] = prev_sum;
-      prev_sum = sum;
-    }
-  }
-  histogram_ps[RDX_HIST_SIZE * (nthreads - 1) + 127] = prev_sum;
-  TORCH_CHECK(prev_sum == elements_count);
-}
-
 template <typename K, typename V>
 void radix_sort_kernel(
     K* input_keys,
@@ -96,10 +54,9 @@ void radix_sort_kernel(
     int elements_count,
     int* histogram,
     int* histogram_ps,
-    int pass,
-    bool with_special_pass = false) {
-  const int tid = omp_get_thread_num();
-  const int nthreads = omp_get_num_threads();
+    int pass) {
+  int tid = omp_get_thread_num();
+  int nthreads = omp_get_num_threads();
   int elements_count_4 = elements_count / 4 * 4;
 
   int* local_histogram = &histogram[RDX_HIST_SIZE * tid];
@@ -131,11 +88,16 @@ void radix_sort_kernel(
 #pragma omp barrier
   // Step 2: prefix sum
   if (tid == 0) {
-    if (with_special_pass) {
-      combine_prefix_sum_for_neg_vals(nthreads, elements_count, histogram, histogram_ps);
-    } else {
-      combine_prefix_sum(nthreads, elements_count, histogram, histogram_ps);
+    int sum = 0, prev_sum = 0;
+    for (int bins = 0; bins < RDX_HIST_SIZE; bins++) {
+      for (int t = 0; t < nthreads; t++) {
+        sum += histogram[t * RDX_HIST_SIZE + bins];
+        histogram_ps[t * RDX_HIST_SIZE + bins] = prev_sum;
+        prev_sum = sum;
+      }
     }
+    histogram_ps[RDX_HIST_SIZE * nthreads] = prev_sum;
+    TORCH_CHECK(prev_sum == elements_count);
   }
 #pragma omp barrier
 
@@ -187,9 +149,8 @@ std::pair<K*, V*> radix_sort_parallel(
     K* tmp_key_buf,
     V* tmp_value_buf,
     int64_t elements_count,
-    int64_t max_value,
-    bool maybe_with_neg_vals = false) {
-  const int maxthreads = omp_get_max_threads();
+    int64_t max_value) {
+  int maxthreads = omp_get_max_threads();
   std::unique_ptr<int []> histogram_tmp(new int[RDX_HIST_SIZE * maxthreads]);
   std::unique_ptr<int []> histogram_ps_tmp(new int[RDX_HIST_SIZE * maxthreads + 1]);
   int* histogram = histogram_tmp.get();
@@ -198,12 +159,8 @@ std::pair<K*, V*> radix_sort_parallel(
     return std::make_pair(inp_key_buf, inp_value_buf);
   }
 
-  // if negative values are present, we want to perform all passes
-  // up to a sign bit
-  int num_bits = sizeof(K) * 8;
-  if (!maybe_with_neg_vals)
-    // __builtin_clz is not portable
-    num_bits -= llvm::countLeadingZeros(static_cast<std::make_unsigned_t<K>>(max_value));
+  // __builtin_clz is not portable
+  int num_bits = sizeof(K) * 8 - llvm::countLeadingZeros(static_cast<std::make_unsigned_t<K>>(max_value));
   unsigned int num_passes = (num_bits + 7) / 8;
 
 #pragma omp parallel
@@ -222,8 +179,7 @@ std::pair<K*, V*> radix_sort_parallel(
           elements_count,
           histogram,
           histogram_ps,
-          pass,
-          maybe_with_neg_vals && pass == num_passes - 1);
+          pass);
 
       std::swap(input_keys, output_keys);
       std::swap(input_values, output_values);

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -8,7 +8,7 @@ from torch import nan
 from itertools import permutations, product
 
 from torch.testing import make_tensor
-from torch.testing._internal.common_dtype import all_types, all_types_and, floating_types_and
+from torch.testing._internal.common_dtype import all_types, all_types_and, floating_types_and, integral_types
 from torch.testing._internal.common_utils import \
     (TestCase, run_tests, slowTest)
 from torch.testing._internal.common_device_type import \
@@ -249,6 +249,15 @@ class TestSortAndSelect(TestCase):
         values_cont, indices_cont = tensor.sort()
         self.assertEqual(indices, indices_cont)
         self.assertEqual(values, values_cont)
+
+    @slowTest
+    @onlyCPU
+    @dtypes(*integral_types())
+    def test_sort_1d_parallel(self, device, dtype):
+        low = 0 if dtype == torch.uint8 else -128
+        tensor = torch.randint(low=low, high=127, size=(100000, ), device=device, dtype=dtype)
+        vals, _ = torch.sort(tensor, stable=True)
+        self.assertEqual(True, torch.all(vals[:-1] <= vals[1:]))
 
     @dtypes(torch.float32)
     def test_topk_1d_output_discontiguous(self, device, dtype):


### PR DESCRIPTION
In GNN workloads we use `torch.argsort` to calculate permutation from CSR to CSC sparse matrix storage format. Till now, sorting one-dimensional data was performed sequentially. This change reuses radix sort from [fbgemm](https://github.com/dszwicht/FBGEMM/pull/1) and makes `torch.(arg)sort` work in parallel.

Performance measurements (measured on ICX platform - 40C):
```
| Size        | Before [s] | Now [s] | Speedup |
|-------------|------------|---------|---------|
| 10^5        | 0.0107     | 0.002   | 5.35x   |
| 4 * 10^5    | 0.0402     | 0.0059  | 6.81x   |
| 16 * 10^5   | 0.1756     | 0.0159  | 11.04x  |
| 64 * 10^5   | 0.7659     | 0.0626  | 12.23x  |
| 256 * 10^5  | 3.2334     | 0.2636  | 12.26x  |
| 1024 * 10^5 | 13.356     | 1.0283  | 12.98x  |
```


